### PR TITLE
Reset Password redirection to frontend

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -17,7 +17,7 @@ const refreshToken = async (req, res, next) => {
     const decoded = jwt.verify(oldToken, process.env.JWT_SECRET);
     
     // Access token is valid, generate new refresh token
-    const newRefreshToken = generateToken({ id: decoded.id }, process.env.JWT_SECRET, process.env.JWT_REFRESH_EXPIRES_IN);
+    const newRefreshToken = generateToken({ id: decoded.id }, process.env.JWT_REFRESH_SECRET, process.env.JWT_REFRESH_EXPIRES_IN);
 
     // Set new refresh token in cookies
     res.cookie("refreshToken", newRefreshToken, { httpOnly: true, secure: process.env.NODE_ENV === 'production' });
@@ -27,14 +27,14 @@ const refreshToken = async (req, res, next) => {
   } catch (error) {
     // Token is invalid, verify the refresh token
     try {
-      const decodedRefresh = jwt.verify(oldRefreshToken, process.env.JWT_SECRET);
+      const decodedRefresh = jwt.verify(oldRefreshToken, process.env.JWT_REFRESH_SECRET);
       if (!decodedRefresh) {
         return res.status(401).json({ status: "fail", message: "Invalid refresh token" });
       }
 
       // Generate new tokens
       const newToken = generateToken({ id: decodedRefresh.id }, process.env.JWT_SECRET, process.env.JWT_EXPIRES_IN);
-      const newRefreshToken = generateToken({ id: decodedRefresh.id }, process.env.JWT_SECRET, process.env.JWT_REFRESH_EXPIRES_IN);
+      const newRefreshToken = generateToken({ id: decodedRefresh.id }, process.env.JWT_REFRESH_SECRET, process.env.JWT_REFRESH_EXPIRES_IN);
 
       // Set new tokens in cookies
       res.cookie("token", newToken, { httpOnly: true, secure: process.env.NODE_ENV === 'production' });

--- a/backend/controllers/resetPasswordController.js
+++ b/backend/controllers/resetPasswordController.js
@@ -46,7 +46,7 @@ const authorizeResetToken = async (req, res) => {
     res.cookie('token', token, { httpOnly: true, sameSite: 'strict' });
     // redirect to reset password page
     console.log(`Page is redirected to ${process.env.FRONTEND_URL}/resetpassword`)
-    return res.redirect(`${process.env.FRONTEND_URL}/auth/reset-password`);
+    return res.redirect(`${process.env.FRONTEND_URL}/auth/change-password`);
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
       return res.status(400).json({ status: 'fail', message: 'Invalid or expired token' });

--- a/backend/controllers/resetPasswordController.js
+++ b/backend/controllers/resetPasswordController.js
@@ -24,7 +24,7 @@ const sendPasswordResetEmail = async (req, res) => {
     return res.status(200).json({
       status: 'success',
       message: 'Password reset email sent',
-      link: `http://localhost:${process.env.PORT}/api/resetpassword/reset-link/${token}`
+      link: `${process.env.BACKEND_URL}/api/resetpassword/reset-link/${token}`
     });
   } catch (error) {
     console.error(error);
@@ -44,7 +44,10 @@ const authorizeResetToken = async (req, res) => {
       return res.status(404).json({ status: 'fail', message: 'User not found' });
     }
     res.cookie('token', token, { httpOnly: true, sameSite: 'strict' });
-    return res.status(200).json({ status: 'success', message: 'Token authorized' });
+    // redirect to reset password page
+    console.log(`Page is redirected to ${process.env.FRONTEND_URL}/resetpassword`)
+    return res.redirect(`${process.env.FRONTEND_URL}/resetpassword`);
+    //return res.status(200).json({ status: 'success', message: 'Token authorized' });
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
       return res.status(400).json({ status: 'fail', message: 'Invalid or expired token' });
@@ -79,8 +82,6 @@ const resetPassword = async (req, res) => {
     // delete cookie after successful password change
     res.clearCookie('token');
     return res.status(200).json({ status: 'success', message: 'Password reset successfully' });
-    // delete cookie
-
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
       return res.status(400).json({ status: 'fail', message: 'Invalid or expired token' });

--- a/backend/controllers/resetPasswordController.js
+++ b/backend/controllers/resetPasswordController.js
@@ -12,7 +12,7 @@ const sendPasswordResetEmail = async (req, res) => {
     if (!user) {
       return res.status(404).json({ status: 'fail', message: 'User not found' });
     }
-    const token = generateToken({ id: user.id }, process.env.JWT_SECRET,  process.env.JWT_RESET_EXPIRES_IN);
+    const token = generateToken({ id: user.id }, process.env.JWT_RESET_SECRET,  process.env.JWT_RESET_EXPIRES_IN);
 
     // send email
     const address = email;
@@ -38,7 +38,7 @@ const authorizeResetToken = async (req, res) => {
     return res.status(400).json({ status: 'fail', message: 'Token must be provided' });
   }
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, process.env.JWT_RESET_SECRET);
     const user = await db.User.findByPk(decoded.id);
     if (!user) {
       return res.status(404).json({ status: 'fail', message: 'User not found' });
@@ -62,7 +62,7 @@ const resetPassword = async (req, res) => {
     return res.status(400).json({ status: 'fail', message: 'Token must be provided' });
   }
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, process.env.JWT_RESET_SECRET);
     const user = await db.User.findByPk(decoded.id);
     if (!user) {
       return res.status(404).json({ status: 'fail', message: 'User not found' });

--- a/backend/controllers/resetPasswordController.js
+++ b/backend/controllers/resetPasswordController.js
@@ -46,8 +46,7 @@ const authorizeResetToken = async (req, res) => {
     res.cookie('token', token, { httpOnly: true, sameSite: 'strict' });
     // redirect to reset password page
     console.log(`Page is redirected to ${process.env.FRONTEND_URL}/resetpassword`)
-    return res.redirect(`${process.env.FRONTEND_URL}/resetpassword`);
-    //return res.status(200).json({ status: 'success', message: 'Token authorized' });
+    return res.redirect(`${process.env.FRONTEND_URL}/auth/reset-password`);
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
       return res.status(400).json({ status: 'fail', message: 'Invalid or expired token' });

--- a/backend/env-sample
+++ b/backend/env-sample
@@ -1,19 +1,27 @@
-# PostgreSQL connection details
+# DATABASE SETTINGS
+
 PGHOST='your-postgres-hostname'
 PGDATABASE='your-database-name'
 PGUSER='your-database-username'
 PGPASSWORD='your-database-password'
 
-# JWT settings
+# JWT SETTINGS
+
 JWT_SECRET='secret'  # change this!!!
 JWT_EXPIRES_IN='30s'
+JWT_REFRESH_SECRET='refreshsecret'  # change this!!!
 JWT_REFRESH_EXPIRES_IN='1d'
+JWT_RESET_SECRET='resetsecret'  # change this!!!
+JWT_RESET_EXPIRES_IN='15m'
 
-# server settings
+# SERVER SETTINGS
+
 PORT=3000
 NODE_ENV='production'
 FRONTEND_URL='http://localhost:5173'
+BACKEND_URL='http://localhost:3000'
 
 # EMAIL SETTINGS
+
 MAIL_USER='user@mail.com'
 MAIL_PASSWORD='some real password'


### PR DESCRIPTION
Closes #112
**Backend Endpoint changed**
- Upon clicking the link sent by email (in our dev  version the link is also sent in a response), the token is loaded into browser and instead of the response, the redirection is activated to the frontend password change form.


**.env UPDATES**
- please, update `.env` file with the version communicated!!!
- Refresh token, Access token, and Reset token are now generated with different keys - improved security.