### PR TITLE
add comma formatting to wallet amount

### DIFF
--- a/frontend/src/components/wallet/wallet.tsx
+++ b/frontend/src/components/wallet/wallet.tsx
@@ -41,7 +41,7 @@ export const Wallet = () => {
   }, [searchParams]);
   // format blanace from cents to dollar/cents with necessary 0s
   const formatBalance = (balanceCents: number) => {
-    return (balanceCents / 100).toFixed(2);
+    return (balanceCents / 100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   };
 
   // initiate modal to topof wallet


### PR DESCRIPTION
if merged, this fix will:
- add formatting to wallet amount to display commas correctly
- ie $1234567.00 will become 1,234,567.00